### PR TITLE
Allow wishlist viewers to grant wishes

### DIFF
--- a/app/Http/Controllers/GrantedWishController.php
+++ b/app/Http/Controllers/GrantedWishController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Wish;
+use Illuminate\Http\Request;
+
+class GrantedWishController extends Controller
+{
+    public function store(Request $request, Wish $wish)
+    {
+        $wish->grant($request->user())->save();
+
+        return back();
+    }
+
+    public function destroy(Wish $wish)
+    {
+        $wish->ungrant()->save();
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -31,8 +31,15 @@ class WishlistController extends Controller
         return to_route('wishlists.show', $wishlist);
     }
 
-    public function show(Wishlist $wishlist)
+    public function show(Request $request, Wishlist $wishlist)
     {
+        if ($request->user()->can('fulfill', $wishlist)) {
+            return view('wishlists.fulfill', [
+                'wishlist' => $wishlist,
+                'wishes' => $wishlist->wishes()->with('granter')->get(),
+            ]);
+        }
+
         return view('wishlists.show', [
             'wishlist' => $wishlist,
             'wishes' => $wishlist->wishes,

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -19,6 +19,23 @@ class Wish extends Model
 
     public function granter()
     {
-        return $this->belongsTo(User::class, 'granter_id');
+        return $this->belongsTo(User::class, 'granter_id')->withDefault();
+    }
+
+    public function granted()
+    {
+        return ! is_null($this->granter_id);
+    }
+
+    public function grant($user)
+    {
+        $this->granter()->associate($user);
+
+        return $this;
+    }
+
+    public function ungrant()
+    {
+        return $this->granter()->dissociate();
     }
 }

--- a/app/Policies/WishPolicy.php
+++ b/app/Policies/WishPolicy.php
@@ -19,7 +19,12 @@ class WishPolicy
 
     public function grant(User $user, Wish $wish): bool
     {
-        return $user->can('fulfill', $wish->wishlist);
+        return ! $wish->granter->exists && $user->can('fulfill', $wish->wishlist);
+    }
+
+    public function ungrant(User $user, Wish $wish): bool
+    {
+        return $user->is($wish->granter);
     }
 
     public function create(User $user): bool

--- a/database/factories/WishFactory.php
+++ b/database/factories/WishFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use App\Models\Wishlist;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -15,5 +16,12 @@ class WishFactory extends Factory
             'url' => $this->faker->url(),
             'description' => $this->faker->sentence(),
         ];
+    }
+
+    public function granted(): static
+    {
+        return $this->state([
+            'granter_id' => User::factory(),
+        ]);
     }
 }

--- a/resources/views/wishlists/fulfill.blade.php
+++ b/resources/views/wishlists/fulfill.blade.php
@@ -1,0 +1,81 @@
+<x-app-layout>
+<x-slot name="header">
+    <h1 class="font-semibold text-xl text-gray-800 leading-tight">
+        {{ $wishlist->name }}
+    </h1>
+</x-slot>
+<div class="py-12">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+        <div class="bg-white divide-y shadow overflow-hidden sm:rounded-lg">
+            @if($wishes->isNotEmpty())
+                <ul role="list" x-init id="wishlist_{{ $wishlist->id }}" x-merge="morph" class="bg-white divide-y">
+                    @foreach($wishes as $wish)
+                        <li class="flex gap-6 px-4 pl-2 py-3 sm:px-8 sm:pl-4 sm:py-4">
+                            <div class="flex-1 flex gap-2 sm:gap-4">
+                                <div>
+                                    @if($wish->granted())
+                                        @can('ungrant', $wish)
+                                            <x-form x-target="wishlist_{{ $wishlist->id }}" method="delete" action="{{ route('wishes.grants.destroy', $wish) }}" class="flex">
+                                                <button aria-pressed="true" aria-describedby="wish_{{ $wish->id }}_name">
+                                                    <svg aria-hidden="true" class="text-blue-600" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                                        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                                        <path d="M18.333 2c1.96 0 3.56 1.537 3.662 3.472l.005 .195v12.666c0 1.96 -1.537 3.56 -3.472 3.662l-.195 .005h-12.666a3.667 3.667 0 0 1 -3.662 -3.472l-.005 -.195v-12.666c0 -1.96 1.537 -3.56 3.472 -3.662l.195 -.005h12.666zm-2.626 7.293a1 1 0 0 0 -1.414 0l-3.293 3.292l-1.293 -1.292l-.094 -.083a1 1 0 0 0 -1.32 1.497l2 2l.094 .083a1 1 0 0 0 1.32 -.083l4 -4l.083 -.094a1 1 0 0 0 -.083 -1.32z" stroke-width="0" fill="currentColor" />
+                                                    </svg>
+                                                    <span class="sr-only">Granted</span>
+                                                </button>
+                                            </x-form>
+                                        @else
+                                            <button aria-disabled="true" aria-pressed="true"  aria-describedby="wish_{{ $wish->id }}_name">
+                                                <svg aria-hidden="true" class="text-blue-600" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                                    <path d="M18.333 2c1.96 0 3.56 1.537 3.662 3.472l.005 .195v12.666c0 1.96 -1.537 3.56 -3.472 3.662l-.195 .005h-12.666a3.667 3.667 0 0 1 -3.662 -3.472l-.005 -.195v-12.666c0 -1.96 1.537 -3.56 3.472 -3.662l.195 -.005h12.666zm-2.626 7.293a1 1 0 0 0 -1.414 0l-3.293 3.292l-1.293 -1.292l-.094 -.083a1 1 0 0 0 -1.32 1.497l2 2l.094 .083a1 1 0 0 0 1.32 -.083l4 -4l.083 -.094a1 1 0 0 0 -.083 -1.32z" stroke-width="0" fill="currentColor" />
+                                                </svg>
+                                                <span class="sr-only">Granted</span>
+                                            </button>
+                                        @endcan
+                                    @else
+                                        @can('grant', $wish->setRelation('wishlist', $wishlist))
+                                            <x-form x-target="wishlist_{{ $wishlist->id }}" method="post" action="{{ route('wishes.grants.store', $wish) }}" class="flex">
+                                                <button aria-pressed="false" aria-describedby="wish_{{ $wish->id }}_name">
+                                                    <svg aria-hidden="true" class="text-gray-300" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                                        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                                        <path d="M19 2h-14a3 3 0 0 0 -3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3 -3v-14a3 3 0 0 0 -3 -3z" stroke-width="0" fill="currentColor" />
+                                                    </svg>
+                                                    <span class="sr-only">Granted</span>
+                                                </button>
+                                            </x-form>
+                                        @else
+                                            <button aria-disabled="true" aria-pressed="false" aria-describedby="wish_{{ $wish->id }}_name">
+                                                <svg aria-hidden="true" class="text-gray-300" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                                    <path d="M19 2h-14a3 3 0 0 0 -3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3 -3v-14a3 3 0 0 0 -3 -3z" stroke-width="0" fill="currentColor" />
+                                                </svg>
+                                                <span class="sr-only">Granted</span>
+                                            </button>
+                                        @endcan
+                                    @endif
+                                </div>
+                                <div>
+                                    <div class="{{ $wish->granted() ? 'text-gray-600 line-through' : '' }}">
+                                        <span id="wish_{{ $wish->id }}_name">{{ $wish->name }}</a>
+                                    </div>
+                                    @if($wish->description)
+                                        <div class="text-sm text-gray-600">{{ $wish->description }}</div>
+                                    @endif
+                                </div>
+                            </div>
+                            <div>
+                                @if($wish->url)
+                                    <a href="{{ $wish->url }}" class="underline text-gray-600 text-sm" aria-describedby="wish_{{ $wish->id }}_name">View</a>
+                                @endif
+                            </div>
+                        </li>
+                    @endforeach
+                </ul>
+            @else
+                <p class="px-4 py-3 text-center text-gray-600 sm:px-8 sm:py-4">{{ __('Nothing has been added to this wishlist (yet).') }}
+            @endif
+        </div>
+    </div>
+</div>
+</x-app-layout>

--- a/resources/views/wishlists/fulfill.blade.php
+++ b/resources/views/wishlists/fulfill.blade.php
@@ -21,7 +21,7 @@
                                                         <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                                                         <path d="M18.333 2c1.96 0 3.56 1.537 3.662 3.472l.005 .195v12.666c0 1.96 -1.537 3.56 -3.472 3.662l-.195 .005h-12.666a3.667 3.667 0 0 1 -3.662 -3.472l-.005 -.195v-12.666c0 -1.96 1.537 -3.56 3.472 -3.662l.195 -.005h12.666zm-2.626 7.293a1 1 0 0 0 -1.414 0l-3.293 3.292l-1.293 -1.292l-.094 -.083a1 1 0 0 0 -1.32 1.497l2 2l.094 .083a1 1 0 0 0 1.32 -.083l4 -4l.083 -.094a1 1 0 0 0 -.083 -1.32z" stroke-width="0" fill="currentColor" />
                                                     </svg>
-                                                    <span class="sr-only">Granted</span>
+                                                    <span class="sr-only">Grant</span>
                                                 </button>
                                             </x-form>
                                         @else
@@ -30,7 +30,7 @@
                                                     <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                                                     <path d="M18.333 2c1.96 0 3.56 1.537 3.662 3.472l.005 .195v12.666c0 1.96 -1.537 3.56 -3.472 3.662l-.195 .005h-12.666a3.667 3.667 0 0 1 -3.662 -3.472l-.005 -.195v-12.666c0 -1.96 1.537 -3.56 3.472 -3.662l.195 -.005h12.666zm-2.626 7.293a1 1 0 0 0 -1.414 0l-3.293 3.292l-1.293 -1.292l-.094 -.083a1 1 0 0 0 -1.32 1.497l2 2l.094 .083a1 1 0 0 0 1.32 -.083l4 -4l.083 -.094a1 1 0 0 0 -.083 -1.32z" stroke-width="0" fill="currentColor" />
                                                 </svg>
-                                                <span class="sr-only">Granted</span>
+                                                <span class="sr-only">Grant</span>
                                             </button>
                                         @endcan
                                     @else
@@ -41,7 +41,7 @@
                                                         <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                                                         <path d="M19 2h-14a3 3 0 0 0 -3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3 -3v-14a3 3 0 0 0 -3 -3z" stroke-width="0" fill="currentColor" />
                                                     </svg>
-                                                    <span class="sr-only">Granted</span>
+                                                    <span class="sr-only">Grant</span>
                                                 </button>
                                             </x-form>
                                         @else
@@ -50,7 +50,7 @@
                                                     <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                                                     <path d="M19 2h-14a3 3 0 0 0 -3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3 -3v-14a3 3 0 0 0 -3 -3z" stroke-width="0" fill="currentColor" />
                                                 </svg>
-                                                <span class="sr-only">Granted</span>
+                                                <span class="sr-only">Grant</span>
                                             </button>
                                         @endcan
                                     @endif

--- a/resources/views/wishlists/show.blade.php
+++ b/resources/views/wishlists/show.blade.php
@@ -35,81 +35,75 @@
             @else
                 <p class="px-4 py-3 text-center text-gray-600 sm:px-8 sm:py-4">{{ __('Nothing has been added to this wishlist (yet).') }}
             @endif
-            @can('update', $wishlist)
-                <div class="bg-white px-4 py-5 sm:px-8 sm:py-6 border-t">
-                    <x-button-primary class="w-full" href="{{ route('wishes.create', $wishlist) }}">Add a wish</x-button-primary>
-                </div>
-            @endcan
+            <div class="bg-white px-4 py-5 sm:px-8 sm:py-6 border-t">
+                <x-button-primary class="w-full" href="{{ route('wishes.create', $wishlist) }}">Add a wish</x-button-primary>
+            </div>
         </div>
 
-        @can('update', $wishlist)
-            <section class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+        <section class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+            <header>
+                <h2 class="text-lg font-medium text-gray-900">
+                    {{ __('Share') }}
+                </h2>
+                <p class="mt-1 text-sm text-gray-600">
+                    {{ __('Use this link to share your wishlist with others.') }}
+                </p>
+            </header>
+            <div x-data="{
+                canCopy: window.navigator.clipboard,
+                copied: false,
+                select() {
+                    this.$refs.input.setSelectionRange(0, this.$refs.input.value.length)
+                },
+                copy() {
+                    window.navigator.clipboard.writeText(this.$refs.input.value)
+                    this.copied = true
+                    window.setTimeout(() => this.copied = false, 2000)
+                }
+            }" class="mt-6 flex rounded-md shadow-sm">
+                <label for="share_url" class="sr-only">{{ __('Share URL') }}</label>
+                <input type="url" id="share_url" x-ref="input" readonly x-on:focus="select" value="{{ route('wishlists.viewers.create', $wishlist) }}" x-bind:class="canCopy ? '' : 'rounded-r-md'" class="block w-full rounded-none rounded-l-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6">
+                <button type="button" x-show="canCopy" x-on:click="copy" class="bg-gray-100 relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-200">
+                    <span x-show="!copied" class="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" class="-ml-1 mr-2" viewBox="0 0 24 24" stroke-width="1.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M8 8m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z" />
+                            <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
+                        </svg>
+                        Copy
+                    </span>
+                    <span x-show="copied" class="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" class="-ml-1 mr-2" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M5 12l5 5l10 -10" />
+                        </svg>
+                        Copied
+                    </span>
+                </button>
+            </div>
+        </section>
+
+        <section class="bg-white pt-4 sm:pt-8 divide-y shadow overflow-hidden sm:rounded-lg">
+            <div class="px-4 sm:px-8">
                 <header>
                     <h2 class="text-lg font-medium text-gray-900">
-                        {{ __('Share') }}
+                        {{ __('Viewers') }}
                     </h2>
                     <p class="mt-1 text-sm text-gray-600">
-                        {{ __('Use this link to share your wishlist with others.') }}
+                        {{ __('These are the people who can view your wishlist.') }}
                     </p>
                 </header>
-                <div x-data="{
-                    canCopy: window.navigator.clipboard,
-                    copied: false,
-                    select() {
-                        this.$refs.input.setSelectionRange(0, this.$refs.input.value.length)
-                    },
-                    copy() {
-                        window.navigator.clipboard.writeText(this.$refs.input.value)
-                        this.copied = true
-                        window.setTimeout(() => this.copied = false, 2000)
-                    }
-                }" class="mt-6 flex rounded-md shadow-sm">
-                    <label for="share_url" class="sr-only">{{ __('Share URL') }}</label>
-                    <input type="url" id="share_url" x-ref="input" readonly x-on:focus="select" value="{{ route('wishlists.viewers.create', $wishlist) }}" x-bind:class="canCopy ? '' : 'rounded-r-md'" class="block w-full rounded-none rounded-l-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6">
-                    <button type="button" x-show="canCopy" x-on:click="copy" class="bg-gray-100 relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-200">
-                        <span x-show="!copied" class="flex items-center">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" class="-ml-1 mr-2" viewBox="0 0 24 24" stroke-width="1.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
-                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                <path d="M8 8m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z" />
-                                <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
-                            </svg>
-                            Copy
-                        </span>
-                        <span x-show="copied" class="flex items-center">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" class="-ml-1 mr-2" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                <path d="M5 12l5 5l10 -10" />
-                            </svg>
-                            Copied
-                        </span>
-                    </button>
-                </div>
-            </section>
-
-            @if($wishlist->viewers->isNotEmpty())
-                <section class="bg-white pt-4 sm:pt-8 divide-y shadow overflow-hidden sm:rounded-lg">
-                    <div class="px-4 sm:px-8">
-                        <header>
-                            <h2 class="text-lg font-medium text-gray-900">
-                                {{ __('Viewers') }}
-                            </h2>
-                            <p class="mt-1 text-sm text-gray-600">
-                                {{ __('These are the people who can view your wishlist.') }}
-                            </p>
-                        </header>
-                    </div>
-                    <div class="mt-6">
-                        <ul class="bg-white divide-y">
-                            @foreach($wishlist->viewers as $viewer)
-                                <li class="flex gap-6 px-4 py-3 sm:px-8 sm:py-4">
-                                    {{ $viewer->name }}
-                                </li>
-                            @endforeach
-                        </ul>
-                    </div>
-                </section>
-            @endif
-        @endif
+            </div>
+            <div class="mt-6">
+                <ul class="bg-white divide-y">
+                    @foreach($wishlist->viewers as $viewer)
+                        <li class="flex gap-6 px-4 py-3 sm:px-8 sm:py-4">
+                            {{ $viewer->name }}
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        </section>
     </div>
 </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\WishController;
 use App\Http\Controllers\WishlistController;
 use App\Http\Controllers\WishlistViewerController;
+use App\Http\Controllers\GrantedWishController;
 use App\Models\Wishlist;
 use Illuminate\Support\Facades\Route;
 
@@ -36,6 +37,9 @@ Route::middleware('auth')->prefix('/app')->group(function () {
     Route::get('/wishlists/{wishlist}/wishes/{wish}/edit', [WishController::class, 'edit'])->name('wishes.edit')->can('update', 'wish');
     Route::patch('/wishlists/{wishlist}/wishes/{wish}', [WishController::class, 'update'])->name('wishes.update')->can('update', 'wish');
     Route::delete('/wishlists/{wishlist}/wishes/{wish}', [WishController::class, 'destroy'])->name('wishes.destroy')->can('delete', 'wish');
+
+    Route::post('/wishes/{wish}/grant', [GrantedWishController::class, 'store'])->name('wishes.grants.store')->can('grant', 'wish');
+    Route::delete('/wishes/{wish}/grant', [GrantedWishController::class, 'destroy'])->name('wishes.grants.destroy')->can('ungrant', 'wish');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/GrantedWishTest.php
+++ b/tests/Feature/GrantedWishTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\User;
+use App\Models\Wish;
+
+test('wishlist owner cannot grant wishes', function () {
+    $wish = Wish::factory()->create();
+
+    $this->actingAs($wish->wishlist->user);
+
+    $this->post(route('wishes.grants.store', $wish), [])->assertForbidden();
+});
+
+test('wishlist owner cannot ungrant wishes', function () {
+    $wish = Wish::factory()->granted()->create();
+
+    $this->actingAs($wish->wishlist->user);
+
+    $this->post(route('wishes.grants.destroy', $wish), [])->assertForbidden();
+});
+
+test('wishlist viewer can grant wishes', function () {
+    $wish = Wish::factory()->create();
+    $viewer = User::factory()->create();
+    $wish->wishlist->viewers()->attach($viewer);
+
+    $this->actingAs($viewer);
+
+    $response = $this->post(route('wishes.grants.store', $wish));
+
+    $response->assertRedirect();
+    expect($wish->fresh()->granted())->toBeTrue();
+});
+
+test('wishlist viewer can ungrant their granted wishes', function () {
+    $viewer = User::factory()->create();
+    $wish = Wish::factory()->for($viewer, 'granter')->create();
+    $wish->wishlist->viewers()->attach($viewer);
+
+    expect($wish->granted())->toBeTrue();
+
+    $this->actingAs($viewer);
+
+    $response = $this->delete(route('wishes.grants.destroy', $wish));
+
+    $response->assertRedirect();
+    expect($wish->fresh()->granted())->toBeFalse();
+});
+
+test('wishlist viewer cannot grant others’ granted wishes', function () {
+    $wish = Wish::factory()->granted()->create();
+    $viewer = User::factory()->create();
+    $wish->wishlist->viewers()->attach($viewer);
+
+    $this->actingAs($viewer);
+
+    $this->post(route('wishes.grants.store', $wish))->assertForbidden();
+});
+
+test('wishlist viewer cannot ungrant others’ granted wishes', function () {
+    $viewerA = User::factory()->create();
+    $viewerB = User::factory()->create();
+    $wish = Wish::factory()->for($viewerB, 'granter')->create();
+    $wish->wishlist->viewers()->attach($viewerA);
+
+    expect($wish->granted())->toBeTrue();
+
+    $this->actingAs($viewerA);
+
+    $this->post(route('wishes.grants.destroy', $wish))->assertForbidden();
+});


### PR DESCRIPTION
### Backend

Viewers of a wishlist have permission to `fulfill` a wishlist. 

`WishlistController::show` has been updated to display a "fulfillment" page for viewers with `fulfill` permission.

On "fulfillment" page users can mark wishes an "granted", signifying that they have purchased the wish.

Wishlist viewers may "un-grant" a wish that they have previously "granted", however they cannot modify the state of wishes that have already been "granted" by another user.

### Frontend

I added a grant/ungrant toggle to wishlist items, click it toggles the status of a wish. I choose a toggle button over a checkbox to indicate that interacting with it will trigger immediate changes to a wish.

The wish state changes are progressively enhanced with [Alpine AJAX](https://alpine-ajax.js.org), so that changing the state of a wish doesn't cause a full page reload; Instead, Alpine AJAX morphs the wishes between states and maintains keyboard focus.

