### PR TITLE
Add keyboard support for drag and drop

### DIFF
--- a/resources/js/components/sortable.js
+++ b/resources/js/components/sortable.js
@@ -3,24 +3,95 @@ import Sortable from 'sortablejs/modular/sortable.core.esm.js';
 export default function (endpoint) {
     return {
         init() {
-            new Sortable(this.$el, {
+            let self = this
+            this.sortable = new Sortable(this.$el, {
                 handle: '[data-handle]',
                 dragClass: 'sortable-drag',
                 ghostClass: 'sortable-ghost',
                 animation: 150,
-                onEnd() {
-                    let body = new FormData()
-                    this.toArray().forEach(id => body.append('sort[]', id))
-
-                    fetch(endpoint, {
-                        method: 'post',
-                        headers: {
-                            'X-Requested-With': 'XMLHttpRequest',
-                            'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
-                        },
-                        body,
-                    })
+                onSort() {
+                    self.save()
                 }
+            })
+        },
+        sortable: null,
+        selected: '',
+        order: [],
+        start: null,
+        cleanup: () => { },
+        announce(message) {
+            document.getElementById('announcer').textContent = message
+        },
+        toggle(event) {
+            if (!this.selected) {
+                this.enableKeyboard(event.target)
+                this.announce(`Grabbed. Current position in list: ${this.start} of ${this.order.length}. Press up and down arrow to change position, Spacebar to drop, Escape to cancel.`)
+            } else {
+                this.save()
+                let index = this.order.indexOf(this.selected)
+                this.announce(`Dropped. Final position in list: ${index + 1} of ${this.order.length}.`)
+                this.disableKeyboard()
+            }
+        },
+        enableKeyboard(element) {
+            this.selected = element.closest('[data-id]').dataset.id
+            this.order = this.sortable.toArray()
+            this.start = this.order.indexOf(this.selected)
+
+            let handler = (event) => {
+                if (event.key === 'ArrowDown') this.next()
+                if (event.key === 'ArrowRight') this.next()
+                else if (event.key === 'ArrowUp') this.previous()
+                else if (event.key === 'ArrowLeft') this.previous()
+                else if (event.key === 'Escape') this.stop()
+                else if (event.key === 'Tab') this.selected && event.preventDefault()
+            }
+
+            element.addEventListener('keydown', handler)
+            this.cleanup = () => element.removeEventListener('keydown', handler)
+        },
+        disableKeyboard() {
+            this.cleanup()
+            this.selected = null
+            this.order = []
+            this.start = null
+        },
+        next() {
+            let index = this.order.indexOf(this.selected)
+            let to = index === this.order.length - 1 ? 0 : index + 1
+            this.move(index, to)
+            this.announce(`New position in list: ${to + 1} of ${this.order.length}.`)
+        },
+        previous() {
+            let index = this.order.indexOf(this.selected)
+            let to = index === 0 ? this.order.length - 1 : index - 1
+            this.move(index, to)
+            this.announce(`New position in list: ${to + 1} of ${this.order.length}.`)
+        },
+        stop() {
+            let index = this.order.indexOf(this.selected)
+            this.move(index, this.start)
+            this.announce(`Dropped. Re-order cancelled.`)
+            this.disableKeyboard()
+        },
+        move(index, to) {
+            this.order.splice(index, 1)
+            this.order.splice(to, 0, this.selected)
+            let focused = document.activeElement
+            this.sortable.sort(this.order, true)
+            focused.focus()
+        },
+        save() {
+            let body = new FormData()
+            this.sortable.toArray().forEach(id => body.append('sort[]', id))
+
+            fetch(endpoint, {
+                method: 'post',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
+                },
+                body,
             })
         }
     }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,6 +7,7 @@
 
         <title>{{ isset($title) ? $title . ' | ' : '' }} Snowbody Knows</title>
 
+        <style>[x-cloak] { display: none; }</style>
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans antialiased">

--- a/resources/views/wishlists/show.blade.php
+++ b/resources/views/wishlists/show.blade.php
@@ -11,12 +11,19 @@
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
         <div class="bg-white divide-y shadow overflow-hidden sm:rounded-lg">
             @if($wishes->isNotEmpty())
+                <div id="announcer" aria-live="assertive" class="sr-only"></div>
+                <div id="sortable_description" class="sr-only">Press spacebar to grab and re-order</div>
                 <ul x-data="sortable('{{ route('wishlists.sort', $wishlist) }}')" role="list" class="bg-white divide-y">
                     @foreach($wishes as $wish)
                         <li data-id="{{ $wish->id }}" class="bg-white flex gap-6 px-4 pl-0 py-3 sm:px-8 sm:py-4">
                             <div class="flex-1 flex sm:gap-4">
-                                <button type="button" data-handle class="flex items-center cursor-move pl-4 pr-2 sm:pr-4">
-                                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="text-gray-300" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                <button type="button" data-handle
+                                    aria-describedby="sortable_description"
+                                    x-on:click.prevent.stop=""
+                                    x-on:keydown.space.prevent="toggle"
+                                    class="flex items-center cursor-move pl-4 pr-2 sm:pr-4"
+                                >
+                                    <svg x-show="selected !== '{{ $wish->id }}'" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="text-gray-300" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                                         <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                                         <path d="M9 5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
                                         <path d="M9 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
@@ -25,14 +32,19 @@
                                         <path d="M15 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
                                         <path d="M15 19m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
                                     </svg>
-                                    <span class="sr-only">Reorder</span>
+                                    <svg x-cloak x-show="selected === '{{ $wish->id }}'" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="text-gray-300" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                        <path d="M8 9l4 -4l4 4" />
+                                        <path d="M16 15l-4 4l-4 -4" />
+                                    </svg>
+                                    <span class="sr-only">Re-order</span>
                                 </button>
                                 <div>
                                     <div>
                                         @if($wish->url)
-                                            <a class="underline" href="{{ $wish->url }}">{{ $wish->name }}</a>
+                                            <a id="wish_{{ $wish->id }}_name" class="underline" href="{{ $wish->url }}">{{ $wish->name }}</a>
                                         @else
-                                            <span>{{ $wish->name }}</span>
+                                            <span id="wish_{{ $wish->id }}_name">{{ $wish->name }}</span>
                                         @endif
                                     </div>
                                     @if($wish->description)
@@ -41,9 +53,9 @@
                                 </div>
                             </div>
                             <div class="flex gap-2">
-                                <a href="{{ route('wishes.edit', [$wishlist, $wish]) }}" class="underline text-gray-600 text-sm">Edit <span class="sr-only">{{ $wish->name }}</span></a>
+                                <a href="{{ route('wishes.edit', [$wishlist, $wish]) }}" class="underline text-gray-600 text-sm" aria-describedby="wish_{{ $wish->id }}_name">Edit</a>
                                 <x-form method="delete" action="{{ route('wishes.destroy', [$wishlist, $wish]) }}" class="text-gray-600 text-sm">
-                                    <button class="underline">Delete <span class="sr-only">{{ $wish->name }}</span></button>
+                                    <button class="underline" aria-describedby="wish_{{ $wish->id }}_name">Delete</button>
                                 </x-form>
                             </div>
                         </li>


### PR DESCRIPTION
Keyboard support is modeled off of [this drag & drop pattern by Salesforce](https://salesforce-ux.github.io/dnd-a11y-patterns/#/sortA?_k=7bgu3o).

Keyboard sorting is triggered with a space bar press on the "re-order" button. The button disables `click` events so that mouse users don't accidentally trigger keyboard sorting.

The arrow keys rearrange the selected wish in an internal `order` array which is passed to `Sortable.sort()` to animate the sorting behavior.

An `aria-live` region is dynamically updated as the list changes to give screen readers additional context.