### PR TITLE
adds 'orderBy' statement

### DIFF
--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -36,7 +36,7 @@ class WishlistController extends Controller
         if ($request->user()->can('fulfill', $wishlist)) {
             return view('wishlists.fulfill', [
                 'wishlist' => $wishlist,
-                'wishes' => $wishlist->wishes()->with('granter')->orderBy('order')->get(),
+                'wishes' => $wishlist->wishes()->with('granter')->orderBy('granter_id', 'asc')->orderBy('order')->get(),
             ]);
         }
 


### PR DESCRIPTION
Fixes #18. If none of the wishes have been granted then they all have `null` for `granter_id` and it doesn't affect the order. If any have been granted they move to the bottom, but the ungranted ones still respect the "Wisher's" ordering