### PR TITLE
Fix redirect for logged-in users to wishlist view on homepage

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,9 @@ use App\Http\Controllers\WishlistController;
 use App\Models\Wishlist;
 use Illuminate\Support\Facades\Route;
 
-Route::view('/', 'welcome')->name('welcome');
+Route::get('/', function () {
+    return auth()->check() ? redirect()->route('wishlists.index') : view('welcome');
+})->name('welcome');
 
 Route::get('/groups/{group:invite_code}/join', JoinController::class)->name('join');
 


### PR DESCRIPTION
This PR resolves the issue where logged-in users returning to the homepage were incorrectly shown the login and register buttons instead of being redirected to the wishlist view page.

Resolves https://github.com/imacrayon/snowbodyknows/issues/48

### Changes:
Updated the homepage route logic to check if the user is authenticated and redirect them to the wishlists.index page.

### Testing:
[x] Verified that logged-in users are redirected to the wishlist view page when accessing the homepage.
[x] Verified that non-authenticated users still see the welcome page with login and register buttons.

### Screen Recording:
https://github.com/user-attachments/assets/d5359520-5fae-4c76-a288-57bf12aa22f1

This ensures a seamless user experience for logged-in users.